### PR TITLE
Merging the Chess.com PUB API scraper

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -55,7 +55,7 @@ def get_games_pgn(username):
         games = requests.get(url=archive, headers=json_header).json()["games"]  # 2d array of game representations
         for game in games:
             # apply game filters here
-            if game["time_class"] == "rapid":
+            if game["time_class"] == "bullet":
                 continue
             filtered_games.append(game["pgn"])
 


### PR DESCRIPTION
Dear team,
I have finally awaken from my seemingly ethereal slumber, but today I bestow upon you my greatest commits every conducted  on this repository.
The scraper is finally finished and can be easily extended by adding names to the list at the beginning. Then for each account the archive - a index of all games sorted by the month played - is opened and each URL is downloaded recursively. After that each game is filtered out by some criteria like the time class and afterwards saved as PGN in memory. Lastly, it is written to a file specified in the `save_dir` variable, therefore clearing the RAM.
Obviously, the code isn't perfect as the RAM could get quite full when downloading a whole chess pro's career, but I tested it and it takes 50 MB max, so that's not really an issue. Furthermore, the code fails after two or three players, which is most likely Chess.com's fault; maybe some kind of DDoS protection. The solution: Perhaps adding a delay ig.
I hope we can soon even out the rough edges left and get the data necessary for training the smartest chess AI in the world!
Yours sincerely,
Samuil